### PR TITLE
Fix incorrect Bundle configuration flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # Settings
 MAKEFILES=Makefile $(wildcard *.mk)
-JEKYLL=bundle config --local set path .vendor/bundle && bundle install && bundle update && bundle exec jekyll
+JEKYLL=bundle config --local path .vendor/bundle && bundle install && bundle update && bundle exec jekyll
 PARSER=bin/markdown_ast.rb
 DST=_site
 


### PR DESCRIPTION
On my machine, Bundle is unable to build this project as a user (without root privileges) because the configuration flag to have Bundle run in a user directory is not set correctly. In particular, the project currently has `bundle config --local path set .vendor/bundle`, but it should be `bundle config --local path .vendor/bundle` (without the `set`). In this commit, I have removed the extraneous `set`, and the project correctly serves on my machine.